### PR TITLE
Feature/support for context parameter

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -17,8 +17,9 @@ declare class Odoo {
      * @param {String} model Model name in Odoo.
      * @param {String} method Name of method in Odoo.
      * @param {Array<Object>} params Params in to execute from Odoo.
+     * @param {Object} [context] Context parameterto execute from Odoo.
      */
-    execute_kw: (model: string, method: string, params: Array<Object>) => Promise<any>;
+    execute_kw: (model: string, method: string, params: Array<Object>, context?: Object | undefined) => Promise<any>;
     /**
      * call workflow in odoo.
      *

--- a/lib/index.js
+++ b/lib/index.js
@@ -100,8 +100,9 @@ var Odoo = /** @class */ (function () {
          * @param {String} model Model name in Odoo.
          * @param {String} method Name of method in Odoo.
          * @param {Array<Object>} params Params in to execute from Odoo.
+         * @param {Object} [context] Context parameterto execute from Odoo.
          */
-        this.execute_kw = function (model, method, params) { return __awaiter(_this, void 0, void 0, function () {
+        this.execute_kw = function (model, method, params, context) { return __awaiter(_this, void 0, void 0, function () {
             var clientOptions, client, fparams;
             return __generator(this, function (_a) {
                 clientOptions = {
@@ -118,8 +119,11 @@ var Odoo = /** @class */ (function () {
                     this.password,
                     model,
                     method,
-                    params
+                    params,
                 ];
+                if (context !== undefined) {
+                    fparams.push(context);
+                }
                 return [2 /*return*/, new Promise(function (resolve, reject) {
                         client.methodCall('execute_kw', fparams, function (error, value) {
                             error ? reject(error) : resolve(value);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "async-odoo-xmlrpc",
-    "version": "1.0.1",
+    "version": "2.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "async-odoo-xmlrpc",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "lodash": "^4.17.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "async-odoo-xmlrpc",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "async-odoo-xmlrpc",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "lodash": "^4.17.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "async-odoo-xmlrpc",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Nodejs client to call Odoo RPC's through xmlrpc library.",
     "author": {
         "name": "NguyenVanTien2009",

--- a/src/index.js
+++ b/src/index.js
@@ -67,8 +67,9 @@ class Odoo {
          * @param {String} model Model name in Odoo.
          * @param {String} method Name of method in Odoo.
          * @param {Array<Object>} params Params in to execute from Odoo.
+         * @param {Object} [context] Context parameterto execute from Odoo.
          */
-        this.execute_kw = async (model, method, params) => {
+        this.execute_kw = async (model, method, params, context) => {
             var clientOptions = {
                 host: this.host,
                 port: this.port,
@@ -85,8 +86,12 @@ class Odoo {
                 this.password,
                 model,
                 method,
-                params
+                params,
             ];
+
+            if (context !== undefined) {
+              fparams.push(context)
+            }
 
             return new Promise((resolve, reject) => {
                 client.methodCall('execute_kw', fparams, (error, value) => {


### PR DESCRIPTION
Some Odoo models (i.e. `account.aged.receivable`) require an additional context parameter for the request to succeed. In case the context parameter is not present, the request fails.

This PR adds support to pass in that extra context parameter. It is optional, so this doesn't introduce a breaking change.